### PR TITLE
refactor: streamline retailx ui

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -28,7 +28,7 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 0.75rem;
+    --radius: 0.25rem;
   }
 
   .dark {
@@ -64,6 +64,6 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans antialiased;
   }
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -45,16 +45,14 @@ export function NavBar({
   canUndo: boolean
 }) {
   return (
-    <nav className="w-full flex bg-background py-4">
-      <div className="flex flex-1 items-center">
-        <div className="flex items-center gap-2">
-          <Logo width={24} height={24} />
-          <h1 className="whitespace-pre">
-            Retail<span className="text-[#ff8800]">X</span>
-          </h1>
-        </div>
-      </div>
-      <div className="flex items-center gap-1 md:gap-4">
+    <nav className="flex w-full items-center justify-between border-b border-border bg-background px-4 py-2">
+      <Link href="/" className="flex items-center gap-2">
+        <Logo width={24} height={24} />
+        <span className="whitespace-pre font-medium">
+          Retail<span className="text-[#ff8800]">X</span>
+        </span>
+      </Link>
+      <div className="flex items-center gap-2">
         <TooltipProvider>
           <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-md border bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- sharpen global border radius and body typography
- simplify navbar layout with crisp spacing
- lighten card component styling for minimal look

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2f71247dc832493cccf90770f55d9