### PR TITLE
refactor: simplify retail fragments

### DIFF
--- a/components/fragment-camera-feed.tsx
+++ b/components/fragment-camera-feed.tsx
@@ -1,716 +1,120 @@
 'use client'
 
 import { CameraFeedFragmentSchema } from '@/lib/schema'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { 
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { 
-  Camera, 
-  MapPin, 
-  Users, 
-  AlertTriangle, 
-  Shield, 
-  Clock,
+import {
+  Camera,
   Maximize2,
   Minimize2,
+  Pause,
+  Play,
   Volume2,
   VolumeX,
-  RotateCcw,
-  Settings,
-  Download,
-  Play,
-  Pause,
-  SkipBack,
-  SkipForward,
-  Zap,
-  Wifi,
-  WifiOff,
-  Eye,
-  EyeOff,
-  RefreshCw,
-  X
 } from 'lucide-react'
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useRef, useState } from 'react'
 
-interface Store {
-  id: string
-  name: string
-  location: string
-  status: 'online' | 'offline' | 'maintenance'
-  cameras: number
-  alerts: number
-  lastUpdate: string
-}
+export function FragmentCameraFeed({
+  fragment,
+}: {
+  fragment: CameraFeedFragmentSchema
+}) {
+  const [current, setCurrent] = useState(0)
+  const [muted, setMuted] = useState(true)
+  const [playing, setPlaying] = useState(true)
+  const [fullscreen, setFullscreen] = useState(false)
+  const frameRef = useRef<HTMLIFrameElement>(null)
 
-interface CameraFeed {
-  id: string
-  location: string
-  url: string
-  status: 'online' | 'offline' | 'recording' | 'maintenance'
-  resolution: string
-  fps: number
-  hasAudio: boolean
-  hasMotionDetection: boolean
-  lastMotion?: string
-  viewerCount: number
-  recordingTime: string
-}
+  const cameras = fragment.camera_locations.map((location, i) => ({
+    location,
+    url: fragment.camera_feed_url.replace('{id}', String(i + 1)),
+  }))
 
-export function FragmentCameraFeed({ fragment }: { fragment: CameraFeedFragmentSchema }) {
-  const [selectedStore, setSelectedStore] = useState<string>('')
-  const [selectedCamera, setSelectedCamera] = useState(0)
-  const [isFullscreen, setIsFullscreen] = useState(false)
-  const [isMuted, setIsMuted] = useState(true)
-  const [isPlaying, setIsPlaying] = useState(true)
-  const [lastRefresh, setLastRefresh] = useState(new Date())
-  const videoRef = useRef<HTMLVideoElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
+  const main = cameras[current]
 
-  // YouTube video URLs converted to embed format
-  const youtubeVideos = [
-    'https://www.youtube.com/embed/lEddHr7oq98?autoplay=1&mute=1&loop=1&playlist=lEddHr7oq98',
-    'https://www.youtube.com/embed/9BTrF3YiqTI?autoplay=1&mute=1&loop=1&playlist=9BTrF3YiqTI',
-    'https://www.youtube.com/embed/eSuGpBjRaxw?autoplay=1&mute=1&loop=1&playlist=eSuGpBjRaxw',
-    'https://www.youtube.com/embed/E_2esIdzQxw?autoplay=1&mute=1&loop=1&playlist=E_2esIdzQxw',
-    'https://www.youtube.com/embed/R_2IAJOYdQE?autoplay=1&mute=1&loop=1&playlist=R_2IAJOYdQE',
-    'https://www.youtube.com/embed/KOVd1IwZoMk?autoplay=1&mute=1&loop=1&playlist=KOVd1IwZoMk',
-    'https://www.youtube.com/embed/k5enOLJbjgQ?autoplay=1&mute=1&loop=1&playlist=k5enOLJbjgQ'
-  ]
-
-  // Memoize store data to prevent useEffect dependency issues
-  const stores: Store[] = useMemo(() => [
-    {
-      id: 'main',
-      name: fragment.store_name || 'Main Store',
-      location: '123 Main Street, Downtown',
-      status: 'online',
-      cameras: 8,
-      alerts: 2,
-      lastUpdate: '2 minutes ago'
-    },
-    {
-      id: 'mall',
-      name: 'Mall Location',
-      location: 'Westfield Shopping Center',
-      status: 'online',
-      cameras: 12,
-      alerts: 0,
-      lastUpdate: '1 minute ago'
-    },
-    {
-      id: 'suburban',
-      name: 'Suburban Branch',
-      location: '456 Oak Avenue, Suburbs',
-      status: 'online',
-      cameras: 6,
-      alerts: 1,
-      lastUpdate: '3 minutes ago'
-    },
-    {
-      id: 'airport',
-      name: 'Airport Terminal',
-      location: 'Terminal 2, Gate Area',
-      status: 'maintenance',
-      cameras: 4,
-      alerts: 3,
-      lastUpdate: '15 minutes ago'
-    },
-    {
-      id: 'downtown',
-      name: 'Downtown Express',
-      location: '789 Business District',
-      status: 'offline',
-      cameras: 5,
-      alerts: 5,
-      lastUpdate: '1 hour ago'
-    }
-  ], [fragment.store_name])
-
-  // Set initial store selection
-  useEffect(() => {
-    if (!selectedStore && stores.length > 0) {
-      setSelectedStore(stores[0].id)
-    }
-  }, [stores, selectedStore])
-
-  const currentStore = stores.find(store => store.id === selectedStore) || stores[0]
-
-  // Generate enhanced camera feeds based on selected store
-  const generateCameraFeeds = (store: Store): CameraFeed[] => {
-    const baseLocations = [
-      'Main Entrance', 'Checkout Counter 1', 'Checkout Counter 2', 'Aisle 1-3', 
-      'Aisle 4-6', 'Storage Room', 'Employee Break Room', 'Parking Lot',
-      'Loading Dock', 'Customer Service', 'Electronics Section', 'Pharmacy'
-    ]
-    
-    return Array.from({ length: store.cameras }, (_, index) => ({
-      id: `cam-${store.id}-${index + 1}`,
-      location: baseLocations[index] || `Camera ${index + 1}`,
-      url: youtubeVideos[index % youtubeVideos.length],
-      status: store.status === 'offline' ? 'offline' : 
-              store.status === 'maintenance' ? 'maintenance' :
-              Math.random() > 0.1 ? 'recording' : 'online',
-      resolution: ['1080p', '720p', '4K'][Math.floor(Math.random() * 3)],
-      fps: [30, 60][Math.floor(Math.random() * 2)],
-      hasAudio: Math.random() > 0.3,
-      hasMotionDetection: Math.random() > 0.2,
-      lastMotion: Math.random() > 0.5 ? `${Math.floor(Math.random() * 30) + 1} min ago` : undefined,
-      viewerCount: Math.floor(Math.random() * 5) + 1,
-      recordingTime: `${Math.floor(Math.random() * 24)}:${Math.floor(Math.random() * 60).toString().padStart(2, '0')}`
-    }))
-  }
-
-  const cameraFeeds = generateCameraFeeds(currentStore)
-  const currentCamera = cameraFeeds[selectedCamera] || cameraFeeds[0]
-
-  const refreshFeeds = () => {
-    setLastRefresh(new Date())
-    // In real app, this would trigger a data refresh
-  }
-
-  const toggleFullscreen = () => {
-    setIsFullscreen(!isFullscreen)
-  }
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'online': return 'text-green-600 border-green-600'
-      case 'recording': return 'text-blue-600 border-blue-600'
-      case 'offline': return 'text-red-600 border-red-600'
-      case 'maintenance': return 'text-yellow-600 border-yellow-600'
-      default: return 'text-gray-600 border-gray-600'
-    }
-  }
-
-  const getStoreStatusColor = (status: string) => {
-    switch (status) {
-      case 'online': return 'bg-green-500'
-      case 'offline': return 'bg-red-500'
-      case 'maintenance': return 'bg-yellow-500'
-      default: return 'bg-gray-500'
-    }
-  }
-
-  // Fullscreen component
-  if (isFullscreen) {
-    return (
-      <div 
-        ref={containerRef}
-        className="fixed inset-0 bg-black z-50 flex flex-col"
-        style={{ zIndex: 9999 }}
-      >
-        {/* Fullscreen Header */}
-        <div className="bg-black/90 text-white p-4 flex items-center justify-between">
-          <div className="flex items-center space-x-4">
-            <div className="flex items-center space-x-2">
-              <Camera className="h-5 w-5" />
-              <span className="font-medium">{currentStore.name} - {currentCamera?.location}</span>
-            </div>
-            <Badge variant="outline" className="text-white border-white">
-              {currentCamera?.resolution} • {currentCamera?.fps}fps
-            </Badge>
-            {currentCamera?.status === 'recording' && (
-              <div className="flex items-center space-x-2">
-                <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse" />
-                <span className="text-sm">LIVE</span>
-              </div>
-            )}
-          </div>
-          
-          <div className="flex items-center space-x-2">
-            <Button
-              onClick={() => setIsPlaying(!isPlaying)}
-              variant="outline"
-              size="sm"
-              className="text-white border-white hover:bg-white/20"
-            >
-              {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
-            </Button>
-            <Button
-              onClick={() => setIsMuted(!isMuted)}
-              variant="outline"
-              size="sm"
-              disabled={!currentCamera?.hasAudio}
-              className="text-white border-white hover:bg-white/20"
-            >
-              {isMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
-            </Button>
-            <Button
-              onClick={toggleFullscreen}
-              variant="outline"
-              size="sm"
-              className="text-white border-white hover:bg-white/20"
-            >
-              <Minimize2 className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-
-        {/* Fullscreen Video */}
-        <div className="flex-1 relative bg-black">
-          {currentCamera?.status === 'offline' ? (
-            <div className="w-full h-full flex items-center justify-center text-white">
-              <div className="text-center">
-                <WifiOff className="h-16 w-16 mx-auto mb-4 text-red-500" />
-                <div className="text-2xl font-medium">Camera Offline</div>
-                <div className="text-lg text-gray-400">Unable to connect to camera feed</div>
-              </div>
-            </div>
-          ) : currentCamera?.status === 'maintenance' ? (
-            <div className="w-full h-full flex items-center justify-center text-white">
-              <div className="text-center">
-                <Settings className="h-16 w-16 mx-auto mb-4 text-yellow-500 animate-spin" />
-                <div className="text-2xl font-medium">Under Maintenance</div>
-                <div className="text-lg text-gray-400">Camera is being serviced</div>
-              </div>
-            </div>
-          ) : (
-            <iframe
-              key={`${selectedStore}-${selectedCamera}-fullscreen`}
-              className="w-full h-full"
-              src={currentCamera?.url}
-              title="Camera Feed"
-              frameBorder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-            />
-          )}
-        </div>
-
-        {/* Fullscreen Camera Grid */}
-        <div className="bg-black/90 p-4">
-          <div className="flex items-center space-x-2 overflow-x-auto">
-            {cameraFeeds.map((camera, index) => (
-              <div
-                key={camera.id}
-                className={`flex-shrink-0 cursor-pointer transition-all ${
-                  selectedCamera === index ? 'ring-2 ring-blue-500' : ''
-                }`}
-                onClick={() => setSelectedCamera(index)}
-              >
-                <div className="relative w-24 h-16 bg-gray-800 rounded overflow-hidden">
-                  {camera.status === 'offline' || camera.status === 'maintenance' ? (
-                    <div className="w-full h-full flex items-center justify-center text-white">
-                      {camera.status === 'offline' ? (
-                        <WifiOff className="h-4 w-4 text-red-500" />
-                      ) : (
-                        <Settings className="h-4 w-4 text-yellow-500" />
-                      )}
-                    </div>
-                  ) : (
-                    <iframe
-                      className="w-full h-full object-cover scale-150"
-                      src={camera.url}
-                      title={camera.location}
-                      frameBorder="0"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    />
-                  )}
-                  <div className="absolute bottom-0 left-0 right-0 bg-black/70 text-white px-1 py-0.5">
-                    <div className="text-xs truncate">{camera.location}</div>
-                  </div>
-                  {camera.status === 'recording' && (
-                    <div className="absolute top-1 right-1 w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse" />
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  // Regular view
   return (
-    <div className="flex flex-col h-full">
-      {/* Header with Store Selection */}
-      <div className="flex items-center justify-between p-4 border-b bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950 dark:to-indigo-950">
-        <div className="flex items-center space-x-4">
-          <div className="flex items-center space-x-2">
-            <Camera className="h-5 w-5 text-blue-600" />
-            <h2 className="text-xl font-semibold">Security Camera System</h2>
-          </div>
-          
-          {/* Store Selector */}
-          <div className="flex items-center space-x-2">
-            <span className="text-sm text-muted-foreground">Store:</span>
-            <Select value={selectedStore} onValueChange={setSelectedStore}>
-              <SelectTrigger className="w-64">
-                <SelectValue placeholder="Select a store" />
-              </SelectTrigger>
-              <SelectContent>
-                {stores.map((store) => (
-                  <SelectItem key={store.id} value={store.id}>
-                    <div className="flex items-center space-x-2">
-                      <div className={`w-2 h-2 rounded-full ${getStoreStatusColor(store.status)}`} />
-                      <span>{store.name}</span>
-                      {store.alerts > 0 && (
-                        <Badge variant="destructive" className="text-xs">
-                          {store.alerts}
-                        </Badge>
-                      )}
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <Badge variant="outline" className={getStatusColor(currentStore.status)}>
-            {currentStore.cameras} Cameras • {currentStore.status}
-          </Badge>
-          <Button onClick={refreshFeeds} variant="outline" size="sm">
-            <RefreshCw className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Store Information Panel */}
-      <div className="p-4 border-b">
-        <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950 dark:to-indigo-950">
-          <CardContent className="p-4">
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="flex items-center space-x-2">
-                <MapPin className="h-4 w-4 text-muted-foreground" />
-                <div>
-                  <div className="font-medium text-sm">{currentStore.name}</div>
-                  <div className="text-xs text-muted-foreground">{currentStore.location}</div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Camera className="h-4 w-4 text-muted-foreground" />
-                <div>
-                  <div className="font-medium text-sm">{currentStore.cameras} Cameras</div>
-                  <div className="text-xs text-muted-foreground">Active monitoring</div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-                <div>
-                  <div className="font-medium text-sm">{currentStore.alerts} Alerts</div>
-                  <div className="text-xs text-muted-foreground">Require attention</div>
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
-                <div>
-                  <div className="font-medium text-sm">Last Update</div>
-                  <div className="text-xs text-muted-foreground">{currentStore.lastUpdate}</div>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Main Content Area - Improved Layout */}
-      <div className="flex-1 flex">
-        {/* Camera Selection Panel - Fixed Width */}
-        <div className="w-80 border-r bg-gray-50 dark:bg-gray-900 p-4 overflow-y-auto">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="font-medium text-sm text-muted-foreground">Camera Locations</h3>
-            <Badge variant="outline" className="text-xs">
-              {cameraFeeds.length} cameras
-            </Badge>
-          </div>
-          
-          <div className="space-y-2">
-            {cameraFeeds.map((camera, index) => (
-              <Card 
-                key={camera.id}
-                className={`cursor-pointer transition-all hover:shadow-md ${
-                  selectedCamera === index ? 'ring-2 ring-blue-500 bg-blue-50 dark:bg-blue-950' : ''
-                }`}
-                onClick={() => setSelectedCamera(index)}
-              >
-                <CardContent className="p-3">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                      <MapPin className="h-4 w-4 text-muted-foreground" />
-                      <div>
-                        <div className="text-sm font-medium">{camera.location}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {camera.resolution} • {camera.fps}fps
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex flex-col items-end space-y-1">
-                      <Badge variant="outline" className={`text-xs ${getStatusColor(camera.status)}`}>
-                        {camera.status}
-                      </Badge>
-                      {camera.viewerCount > 0 && (
-                        <div className="flex items-center space-x-1 text-xs text-muted-foreground">
-                          <Users className="h-3 w-3" />
-                          <span>{camera.viewerCount}</span>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                  
-                  {/* Camera Features */}
-                  <div className="flex items-center space-x-2 mt-2">
-                    {camera.hasAudio && <Volume2 className="h-3 w-3 text-green-600" />}
-                    {camera.hasMotionDetection && <Zap className="h-3 w-3 text-blue-600" />}
-                    {camera.status === 'recording' && <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse" />}
-                    {camera.lastMotion && (
-                      <span className="text-xs text-orange-600">Motion: {camera.lastMotion}</span>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
+    <Card className='h-full flex flex-col'>
+      <CardHeader className='flex-row items-center justify-between space-y-0 pb-2'>
+        <CardTitle className='flex items-center space-x-2 text-lg'>
+          <Camera className='h-4 w-4' />
+          <span>{fragment.store_name}</span>
+        </CardTitle>
+        <Select value={String(current)} onValueChange={(v) => setCurrent(Number(v))}>
+          <SelectTrigger className='w-40'>
+            <SelectValue placeholder='Camera' />
+          </SelectTrigger>
+          <SelectContent>
+            {cameras.map((cam, i) => (
+              <SelectItem key={cam.location} value={String(i)}>
+                {cam.location}
+              </SelectItem>
             ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className='flex-1 flex flex-col space-y-4'>
+        <div className='relative aspect-video w-full overflow-hidden rounded bg-black'>
+          <iframe
+            key={current}
+            ref={frameRef}
+            src={main.url}
+            className='h-full w-full'
+            allow='autoplay'
+            allowFullScreen
+          />
+          <div className='absolute bottom-2 right-2 flex space-x-2'>
+            <Button
+              size='sm'
+              variant='secondary'
+              onClick={() => setPlaying((p) => !p)}
+            >
+              {playing ? <Pause className='h-4 w-4' /> : <Play className='h-4 w-4' />}
+            </Button>
+            <Button
+              size='sm'
+              variant='secondary'
+              onClick={() => setMuted((m) => !m)}
+            >
+              {muted ? <VolumeX className='h-4 w-4' /> : <Volume2 className='h-4 w-4' />}
+            </Button>
+            <Button
+              size='sm'
+              variant='secondary'
+              onClick={() => setFullscreen((f) => !f)}
+            >
+              {fullscreen ? (
+                <Minimize2 className='h-4 w-4' />
+              ) : (
+                <Maximize2 className='h-4 w-4' />
+              )}
+            </Button>
           </div>
         </div>
 
-        {/* Main Camera Feed - Takes Remaining Space */}
-        <div className="flex-1 flex flex-col">
-          <Card className="flex-1 m-4 flex flex-col">
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg flex items-center space-x-2">
-                  <MapPin className="h-4 w-4" />
-                  <span>{currentCamera?.location}</span>
-                  <Badge variant="outline" className={getStatusColor(currentCamera?.status || 'offline')}>
-                    {currentCamera?.status}
-                  </Badge>
-                </CardTitle>
-                
-                {/* Camera Controls */}
-                <div className="flex items-center space-x-2">
-                  <Button
-                    onClick={() => setIsPlaying(!isPlaying)}
-                    variant="outline"
-                    size="sm"
-                  >
-                    {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
-                  </Button>
-                  <Button
-                    onClick={() => setIsMuted(!isMuted)}
-                    variant="outline"
-                    size="sm"
-                    disabled={!currentCamera?.hasAudio}
-                  >
-                    {isMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
-                  </Button>
-                  <Button
-                    onClick={toggleFullscreen}
-                    variant="outline"
-                    size="sm"
-                  >
-                    <Maximize2 className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="sm">
-                    <Download className="h-4 w-4" />
-                  </Button>
-                  <Button variant="outline" size="sm">
-                    <Settings className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="p-0 flex-1 flex flex-col">
-              {/* Video Container - Takes Full Available Space */}
-              <div className="flex-1 relative bg-black rounded-b-lg overflow-hidden min-h-[500px]">
-                {currentCamera?.status === 'offline' ? (
-                  <div className="w-full h-full flex items-center justify-center text-white">
-                    <div className="text-center">
-                      <WifiOff className="h-12 w-12 mx-auto mb-4 text-red-500" />
-                      <div className="text-lg font-medium">Camera Offline</div>
-                      <div className="text-sm text-gray-400">Unable to connect to camera feed</div>
-                    </div>
-                  </div>
-                ) : currentCamera?.status === 'maintenance' ? (
-                  <div className="w-full h-full flex items-center justify-center text-white">
-                    <div className="text-center">
-                      <Settings className="h-12 w-12 mx-auto mb-4 text-yellow-500 animate-spin" />
-                      <div className="text-lg font-medium">Under Maintenance</div>
-                      <div className="text-sm text-gray-400">Camera is being serviced</div>
-                    </div>
-                  </div>
-                ) : (
-                  <iframe
-                    key={`${selectedStore}-${selectedCamera}`}
-                    className="w-full h-full"
-                    src={currentCamera?.url}
-                    title="Camera Feed"
-                    frameBorder="0"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                  />
-                )}
-                
-                {/* Video Overlays */}
-                {currentCamera?.status !== 'offline' && currentCamera?.status !== 'maintenance' && (
-                  <>
-                    {/* Camera Info Overlay */}
-                    <div className="absolute top-4 left-4 bg-black/70 text-white px-3 py-2 rounded-md text-sm space-y-1">
-                      <div className="font-medium">{currentStore.name} - {currentCamera?.location}</div>
-                      <div className="text-xs opacity-80">
-                        {currentCamera?.resolution} • {currentCamera?.fps}fps • Recording: {currentCamera?.recordingTime}
-                      </div>
-                    </div>
-                    
-                    {/* Live Indicator */}
-                    <div className="absolute top-4 right-4 flex items-center space-x-2 bg-red-600 text-white px-3 py-2 rounded-md text-sm">
-                      <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
-                      <span>LIVE</span>
-                    </div>
-
-                    {/* Motion Detection Alert */}
-                    {currentCamera?.lastMotion && (
-                      <div className="absolute bottom-4 left-4 bg-orange-600 text-white px-3 py-2 rounded-md text-sm flex items-center space-x-2">
-                        <Zap className="h-4 w-4" />
-                        <span>Motion detected {currentCamera.lastMotion}</span>
-                      </div>
-                    )}
-
-                    {/* Viewer Count */}
-                    <div className="absolute bottom-4 right-4 bg-black/70 text-white px-3 py-2 rounded-md text-sm flex items-center space-x-2">
-                      <Users className="h-4 w-4" />
-                      <span>{currentCamera?.viewerCount} viewing</span>
-                    </div>
-                  </>
-                )}
-              </div>
-
-              {/* Camera Navigation */}
-              <div className="p-4 border-t bg-gray-50 dark:bg-gray-900">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-2">
-                    <Button
-                      onClick={() => setSelectedCamera(Math.max(0, selectedCamera - 1))}
-                      variant="outline"
-                      size="sm"
-                      disabled={selectedCamera === 0}
-                    >
-                      <SkipBack className="h-4 w-4" />
-                    </Button>
-                    <span className="text-sm text-muted-foreground">
-                      Camera {selectedCamera + 1} of {cameraFeeds.length}
-                    </span>
-                    <Button
-                      onClick={() => setSelectedCamera(Math.min(cameraFeeds.length - 1, selectedCamera + 1))}
-                      variant="outline"
-                      size="sm"
-                      disabled={selectedCamera === cameraFeeds.length - 1}
-                    >
-                      <SkipForward className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  
-                  <div className="flex items-center space-x-4 text-sm text-muted-foreground">
-                    <div className="flex items-center space-x-1">
-                      <Wifi className="h-4 w-4" />
-                      <span>Connected</span>
-                    </div>
-                    <div className="flex items-center space-x-1">
-                      <Shield className="h-4 w-4" />
-                      <span>Encrypted</span>
-                    </div>
-                    <span>Last refresh: {lastRefresh.toLocaleTimeString()}</span>
-                  </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        <div className='grid grid-cols-2 gap-2 sm:grid-cols-4'>
+          {cameras.map((cam, i) => (
+            <button
+              key={cam.location}
+              onClick={() => setCurrent(i)}
+              className={`relative aspect-video overflow-hidden rounded border ${
+                current === i ? 'ring-2 ring-primary' : ''
+              }`}
+            >
+              <iframe src={cam.url} className='h-full w-full' allow='autoplay' />
+              <Badge className='absolute left-1 top-1'>{cam.location}</Badge>
+            </button>
+          ))}
         </div>
-      </div>
-
-      {/* Camera Grid View - Bottom Section */}
-      <div className="border-t p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">All Cameras - {currentStore.name}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
-              {cameraFeeds.map((camera, index) => (
-                <Card 
-                  key={camera.id} 
-                  className="overflow-hidden cursor-pointer hover:ring-2 hover:ring-blue-500 transition-all"
-                  onClick={() => setSelectedCamera(index)}
-                >
-                  <div className="relative bg-black" style={{ aspectRatio: '16/9' }}>
-                    {camera.status === 'offline' || camera.status === 'maintenance' ? (
-                      <div className="w-full h-full flex items-center justify-center text-white">
-                        <div className="text-center">
-                          {camera.status === 'offline' ? (
-                            <WifiOff className="h-6 w-6 mx-auto text-red-500" />
-                          ) : (
-                            <Settings className="h-6 w-6 mx-auto text-yellow-500" />
-                          )}
-                          <div className="text-xs mt-1">{camera.status}</div>
-                        </div>
-                      </div>
-                    ) : (
-                      <iframe
-                        className="w-full h-full object-cover"
-                        src={camera.url}
-                        title={camera.location}
-                        frameBorder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        style={{ aspectRatio: '16/9' }}
-                      />
-                    )}
-                    <div className="absolute bottom-1 left-1 bg-black/70 text-white px-2 py-0.5 rounded text-xs">
-                      {camera.location}
-                    </div>
-                    {camera.status === 'recording' && (
-                      <div className="absolute top-1 right-1 w-2 h-2 bg-red-500 rounded-full animate-pulse" />
-                    )}
-                    {camera.lastMotion && (
-                      <div className="absolute top-1 left-1 w-2 h-2 bg-orange-500 rounded-full animate-pulse" />
-                    )}
-                    {selectedCamera === index && (
-                      <div className="absolute inset-0 ring-2 ring-blue-500 ring-inset" />
-                    )}
-                  </div>
-                </Card>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* System Status Footer */}
-      <div className="border-t p-4">
-        <Card className="bg-gray-50 dark:bg-gray-900">
-          <CardContent className="p-4">
-            <div className="grid grid-cols-1 md:grid-cols-5 gap-4 text-sm">
-              <div className="flex items-center space-x-2">
-                <div className="w-2 h-2 bg-green-500 rounded-full" />
-                <span>System Online</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Shield className="h-4 w-4 text-blue-600" />
-                <span>Secure Connection</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Camera className="h-4 w-4 text-green-600" />
-                <span>{cameraFeeds.filter(c => c.status === 'recording').length} Recording</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <AlertTriangle className="h-4 w-4 text-orange-600" />
-                <span>{currentStore.alerts} Active Alerts</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
-                <span>24/7 Monitoring</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   )
 }
+

--- a/components/fragment-dashboard.tsx
+++ b/components/fragment-dashboard.tsx
@@ -1,634 +1,81 @@
 'use client'
 
 import { DashboardFragmentSchema } from '@/lib/schema'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { 
-  BarChart3, 
-  TrendingUp, 
-  Users, 
-  ShoppingCart, 
-  Package, 
-  DollarSign,
-  Calendar,
-  RefreshCw,
-  UserCheck,
-  AlertTriangle,
-  Target,
-  Clock,
-  MapPin,
-  Star,
-  TrendingDown
-} from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { DollarSign, Package, Users } from 'lucide-react'
+import { useState } from 'react'
 
-// Define specific types for each timeframe
-type DailySalesData = {
-  date: string
-  sales: number
-  customers: number
-  transactions: number
-}
+export function FragmentDashboard({
+  fragment,
+}: {
+  fragment: DashboardFragmentSchema
+}) {
+  const [period, setPeriod] = useState(fragment.time_period || 'Today')
 
-type WeeklySalesData = {
-  week: string
-  sales: number
-  customers: number
-  transactions: number
-}
-
-type MonthlySalesData = {
-  month: string
-  sales: number
-  customers: number
-  transactions: number
-}
-
-// Union type for chart data
-type SalesData = DailySalesData | WeeklySalesData | MonthlySalesData
-
-// Define the mock data interface with proper typing
-interface MockDashboardData {
-  salesRevenue: {
-    current: number
-    previous: number
-    trend: 'up' | 'down'
-  }
-  customerTraffic: {
-    current: number
-    previous: number
-    trend: 'up' | 'down'
-  }
-  inventoryLevels: {
-    inStock: number
-    lowStock: number
-    outOfStock: number
-  }
-  avgTransactionValue: {
-    current: number
-    previous: number
-    trend: 'up' | 'down'
-  }
-  topProducts: Array<{
-    name: string
-    sales: number
-    revenue: number
-  }>
-  employees: Array<{
-    name: string
-    role: string
-    status: 'present' | 'break' | 'absent'
-    shift: string
-    performance: number
-  }>
-  storeComparison: Array<{
-    name: string
-    revenue: number
-    growth: number
-    status: 'excellent' | 'good' | 'needs_attention'
-    customers: number
-  }>
-  dailySales: DailySalesData[]
-  weeklySales: WeeklySalesData[]
-  monthlySales: MonthlySalesData[]
-  peakHours: Array<{
-    hour: string
-    customers: number
-    sales: number
-  }>
-  customerSatisfaction: {
-    rating: number
-    reviews: number
-    complaints: number
-    compliments: number
-  }
-}
-
-export function FragmentDashboard({ fragment }: { fragment: DashboardFragmentSchema }) {
-  const [mockData, setMockData] = useState<MockDashboardData>(generateMockData())
-  const [lastUpdated, setLastUpdated] = useState(new Date())
-  const [selectedTimeframe, setSelectedTimeframe] = useState<'daily' | 'weekly' | 'monthly'>('daily')
-
-  function generateMockData(): MockDashboardData {
-    // Generate daily sales data for the last 30 days
-    const dailySales: DailySalesData[] = Array.from({ length: 30 }, (_, i) => ({
-      date: new Date(Date.now() - (29 - i) * 24 * 60 * 60 * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-      sales: Math.floor(Math.random() * 5000) + 1000,
-      customers: Math.floor(Math.random() * 200) + 50,
-      transactions: Math.floor(Math.random() * 150) + 30
-    }))
-
-    // Generate weekly sales data for the last 12 weeks
-    const weeklySales: WeeklySalesData[] = Array.from({ length: 12 }, (_, i) => ({
-      week: `Week ${i + 1}`,
-      sales: Math.floor(Math.random() * 30000) + 10000,
-      customers: Math.floor(Math.random() * 1200) + 400,
-      transactions: Math.floor(Math.random() * 800) + 200
-    }))
-
-    // Generate monthly sales data for the last 12 months
-    const monthlySales: MonthlySalesData[] = Array.from({ length: 12 }, (_, i) => {
-      const date = new Date()
-      date.setMonth(date.getMonth() - (11 - i))
-      return {
-        month: date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' }),
-        sales: Math.floor(Math.random() * 120000) + 40000,
-        customers: Math.floor(Math.random() * 5000) + 1500,
-        transactions: Math.floor(Math.random() * 3000) + 800
-      }
-    })
-
-    return {
-      salesRevenue: {
-        current: Math.floor(Math.random() * 50000) + 10000,
-        previous: Math.floor(Math.random() * 45000) + 8000,
-        trend: Math.random() > 0.5 ? 'up' : 'down'
-      },
-      customerTraffic: {
-        current: Math.floor(Math.random() * 500) + 100,
-        previous: Math.floor(Math.random() * 450) + 80,
-        trend: Math.random() > 0.5 ? 'up' : 'down'
-      },
-      inventoryLevels: {
-        inStock: Math.floor(Math.random() * 1000) + 500,
-        lowStock: Math.floor(Math.random() * 50) + 10,
-        outOfStock: Math.floor(Math.random() * 20) + 5
-      },
-      avgTransactionValue: {
-        current: Math.floor(Math.random() * 100) + 25,
-        previous: Math.floor(Math.random() * 95) + 20,
-        trend: Math.random() > 0.5 ? 'up' : 'down'
-      },
-      topProducts: [
-        { name: 'Premium Coffee Beans', sales: Math.floor(Math.random() * 200) + 50, revenue: Math.floor(Math.random() * 5000) + 1000 },
-        { name: 'Organic Milk', sales: Math.floor(Math.random() * 180) + 40, revenue: Math.floor(Math.random() * 3000) + 800 },
-        { name: 'Fresh Bread', sales: Math.floor(Math.random() * 150) + 30, revenue: Math.floor(Math.random() * 2000) + 600 },
-        { name: 'Energy Drinks', sales: Math.floor(Math.random() * 120) + 25, revenue: Math.floor(Math.random() * 4000) + 900 },
-        { name: 'Snack Mix', sales: Math.floor(Math.random() * 100) + 20, revenue: Math.floor(Math.random() * 1500) + 400 }
-      ],
-      employees: [
-        { name: 'Sarah Johnson', role: 'Store Manager', status: 'present', shift: '9:00 AM - 6:00 PM', performance: 95 },
-        { name: 'Mike Chen', role: 'Cashier', status: 'present', shift: '10:00 AM - 7:00 PM', performance: 88 },
-        { name: 'Emily Davis', role: 'Sales Associate', status: 'present', shift: '8:00 AM - 5:00 PM', performance: 92 },
-        { name: 'James Wilson', role: 'Stock Clerk', status: 'break', shift: '7:00 AM - 4:00 PM', performance: 85 },
-        { name: 'Lisa Brown', role: 'Cashier', status: 'absent', shift: '2:00 PM - 11:00 PM', performance: 78 },
-        { name: 'David Lee', role: 'Security', status: 'present', shift: '6:00 AM - 3:00 PM', performance: 90 }
-      ],
-      storeComparison: [
-        { name: 'Main Store', revenue: 45000, growth: 12.5, status: 'excellent', customers: 1250 },
-        { name: 'Downtown Branch', revenue: 38000, growth: 8.2, status: 'good', customers: 980 },
-        { name: 'Mall Location', revenue: 52000, growth: 15.8, status: 'excellent', customers: 1450 },
-        { name: 'Suburban Store', revenue: 28000, growth: -3.2, status: 'needs_attention', customers: 720 },
-        { name: 'Airport Shop', revenue: 35000, growth: 5.1, status: 'good', customers: 890 }
-      ],
-      dailySales,
-      weeklySales,
-      monthlySales,
-      peakHours: [
-        { hour: '8:00 AM', customers: 45, sales: 1200 },
-        { hour: '12:00 PM', customers: 120, sales: 3200 },
-        { hour: '5:00 PM', customers: 95, sales: 2800 },
-        { hour: '7:00 PM', customers: 75, sales: 2100 }
-      ],
-      customerSatisfaction: {
-        rating: 4.3,
-        reviews: 156,
-        complaints: 8,
-        compliments: 42
-      }
+  const metrics = [
+    {
+      label: 'Sales Revenue',
+      value: '$45k',
+      change: '+12%'
+    },
+    {
+      label: 'Customers',
+      value: '1.2k',
+      change: '+5%'
+    },
+    {
+      label: 'Inventory Items',
+      value: '820'
     }
-  }
+  ]
 
-  function refreshData() {
-    setMockData(generateMockData())
-    setLastUpdated(new Date())
-  }
-
-  function formatCurrency(amount: number) {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD'
-    }).format(amount)
-  }
-
-  function calculatePercentageChange(current: number, previous: number) {
-    return ((current - previous) / previous * 100).toFixed(1)
-  }
-
-  const getCurrentSalesData = (): SalesData[] => {
-    switch (selectedTimeframe) {
-      case 'weekly': return mockData.weeklySales
-      case 'monthly': return mockData.monthlySales
-      default: return mockData.dailySales
-    }
-  }
-
-  // Helper function to get label from sales data item with type safety
-  const getLabel = (item: SalesData, timeframe: 'daily' | 'weekly' | 'monthly'): string => {
-    switch (timeframe) {
-      case 'daily':
-        return 'date' in item ? item.date : ''
-      case 'weekly':
-        return 'week' in item ? item.week : ''
-      case 'monthly':
-        return 'month' in item ? item.month : ''
-      default:
-        return ''
-    }
-  }
-
-  const MetricCard = ({ 
-    title, 
-    value, 
-    previousValue, 
-    trend, 
-    icon: Icon, 
-    formatter = (val: number) => val.toLocaleString() 
-  }: {
-    title: string
-    value: number
-    previousValue?: number
-    trend?: 'up' | 'down'
-    icon: any
-    formatter?: (val: number) => string
-  }) => {
-    const percentChange = previousValue ? calculatePercentageChange(value, previousValue) : null
-    
-    return (
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">{title}</CardTitle>
-          <Icon className="h-4 w-4 text-muted-foreground" />
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{formatter(value)}</div>
-          {percentChange && (
-            <div className={`text-xs flex items-center space-x-1 ${
-              trend === 'up' ? 'text-green-600' : 'text-red-600'
-            }`}>
-              <TrendingUp className={`h-3 w-3 ${trend === 'down' ? 'rotate-180' : ''}`} />
-              <span>{Math.abs(Number(percentChange))}% from last period</span>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    )
-  }
-
-  const SalesChart = () => {
-    const data = getCurrentSalesData()
-    const maxSales = Math.max(...data.map(d => d.sales))
-    
-    return (
-      <Card className="col-span-2">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center space-x-2">
-              <BarChart3 className="h-4 w-4" />
-              <span>Sales Trends</span>
-            </CardTitle>
-            <div className="flex space-x-1">
-              {(['daily', 'weekly', 'monthly'] as const).map((timeframe) => (
-                <Button
-                  key={timeframe}
-                  variant={selectedTimeframe === timeframe ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setSelectedTimeframe(timeframe)}
-                  className="text-xs"
-                >
-                  {timeframe.charAt(0).toUpperCase() + timeframe.slice(1)}
-                </Button>
-              ))}
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div className="h-64 flex items-end space-x-1">
-              {data.slice(-15).map((item, index) => {
-                const height = (item.sales / maxSales) * 100
-                const label = getLabel(item, selectedTimeframe)
-                return (
-                  <div key={index} className="flex-1 flex flex-col items-center">
-                    <div 
-                      className="w-full bg-blue-500 rounded-t-sm hover:bg-blue-600 transition-colors cursor-pointer"
-                      style={{ height: `${height}%` }}
-                      title={`${label}: ${formatCurrency(item.sales)}`}
-                    />
-                    <span className="text-xs text-muted-foreground mt-1 transform -rotate-45 origin-left">
-                      {label}
-                    </span>
-                  </div>
-                )
-              })}
-            </div>
-            <div className="grid grid-cols-3 gap-4 text-sm">
-              <div className="text-center">
-                <div className="font-semibold">{formatCurrency(data[data.length - 1]?.sales || 0)}</div>
-                <div className="text-muted-foreground">Latest Sales</div>
-              </div>
-              <div className="text-center">
-                <div className="font-semibold">{data[data.length - 1]?.customers || 0}</div>
-                <div className="text-muted-foreground">Customers</div>
-              </div>
-              <div className="text-center">
-                <div className="font-semibold">{data[data.length - 1]?.transactions || 0}</div>
-                <div className="text-muted-foreground">Transactions</div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
+  const icons = {
+    'Sales Revenue': DollarSign,
+    Customers: Users,
+    'Inventory Items': Package,
+  } as const
 
   return (
-    <div className="flex flex-col h-full p-4 space-y-6 overflow-y-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-2">
-          <BarChart3 className="h-5 w-5 text-blue-600" />
-          <h2 className="text-xl font-semibold">{fragment.store_name} - Analytics Dashboard</h2>
-          <Badge variant="outline">{fragment.time_period}</Badge>
-        </div>
-        <div className="flex items-center space-x-2">
-          <span className="text-sm text-muted-foreground">
-            Last updated: {lastUpdated.toLocaleTimeString()}
-          </span>
-          <Button
-            onClick={refreshData}
-            variant="outline"
-            size="sm"
-            className="h-8"
-          >
-            <RefreshCw className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Key Metrics Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          title="Sales Revenue"
-          value={mockData.salesRevenue.current}
-          previousValue={mockData.salesRevenue.previous}
-          trend={mockData.salesRevenue.trend}
-          icon={DollarSign}
-          formatter={formatCurrency}
-        />
-        <MetricCard
-          title="Customer Traffic"
-          value={mockData.customerTraffic.current}
-          previousValue={mockData.customerTraffic.previous}
-          trend={mockData.customerTraffic.trend}
-          icon={Users}
-        />
-        <MetricCard
-          title="Avg Transaction"
-          value={mockData.avgTransactionValue.current}
-          previousValue={mockData.avgTransactionValue.previous}
-          trend={mockData.avgTransactionValue.trend}
-          icon={ShoppingCart}
-          formatter={formatCurrency}
-        />
-        <MetricCard
-          title="Items in Stock"
-          value={mockData.inventoryLevels.inStock}
-          icon={Package}
-        />
-      </div>
-
-      {/* Charts and Analytics */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <SalesChart />
-        
-        {/* Peak Hours */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <Clock className="h-4 w-4" />
-              <span>Peak Hours</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {mockData.peakHours.map((hour, index) => (
-                <div key={index} className="flex justify-between items-center">
-                  <div>
-                    <div className="font-medium text-sm">{hour.hour}</div>
-                    <div className="text-xs text-muted-foreground">{hour.customers} customers</div>
-                  </div>
-                  <div className="text-right">
-                    <div className="font-medium text-sm">{formatCurrency(hour.sales)}</div>
-                    <div className="text-xs text-muted-foreground">sales</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Employee Status */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <UserCheck className="h-4 w-4" />
-            <span>Staff Status & Performance</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {mockData.employees.map((employee, index) => (
-              <div key={index} className="border rounded-lg p-3 space-y-2">
-                <div className="flex justify-between items-start">
-                  <div>
-                    <div className="font-medium">{employee.name}</div>
-                    <div className="text-sm text-muted-foreground">{employee.role}</div>
-                  </div>
-                  <Badge 
-                    variant={
-                      employee.status === 'present' ? 'default' : 
-                      employee.status === 'break' ? 'secondary' : 'destructive'
-                    }
-                    className="text-xs"
-                  >
-                    {employee.status}
-                  </Badge>
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  Shift: {employee.shift}
-                </div>
-                <div className="flex items-center space-x-2">
-                  <span className="text-xs">Performance:</span>
-                  <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                    <div 
-                      className={`h-2 rounded-full ${
-                        employee.performance >= 90 ? 'bg-green-500' :
-                        employee.performance >= 80 ? 'bg-yellow-500' : 'bg-red-500'
-                      }`}
-                      style={{ width: `${employee.performance}%` }}
-                    />
-                  </div>
-                  <span className="text-xs font-medium">{employee.performance}%</span>
-                </div>
-              </div>
+    <Card className='h-full flex flex-col'>
+      <CardHeader className='flex-row items-center justify-between space-y-0 pb-2'>
+        <CardTitle className='text-lg'>{fragment.store_name} Dashboard</CardTitle>
+        <Select value={period} onValueChange={setPeriod}>
+          <SelectTrigger className='w-32'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {['Today', 'This Week', 'This Month'].map((p) => (
+              <SelectItem key={p} value={p}>
+                {p}
+              </SelectItem>
             ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Store Performance Comparison */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <MapPin className="h-4 w-4" />
-            <span>Store Performance Comparison</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {mockData.storeComparison.map((store, index) => (
-              <div key={index} className="flex items-center justify-between p-3 border rounded-lg">
-                <div className="flex items-center space-x-3">
-                  <div className={`w-3 h-3 rounded-full ${
-                    store.status === 'excellent' ? 'bg-green-500' :
-                    store.status === 'good' ? 'bg-yellow-500' : 'bg-red-500'
-                  }`} />
-                  <div>
-                    <div className="font-medium">{store.name}</div>
-                    <div className="text-sm text-muted-foreground">{store.customers} customers</div>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="font-medium">{formatCurrency(store.revenue)}</div>
-                  <div className={`text-sm flex items-center space-x-1 ${
-                    store.growth >= 0 ? 'text-green-600' : 'text-red-600'
-                  }`}>
-                    {store.growth >= 0 ? (
-                      <TrendingUp className="h-3 w-3" />
-                    ) : (
-                      <TrendingDown className="h-3 w-3" />
-                    )}
-                    <span>{Math.abs(store.growth)}%</span>
-                  </div>
-                </div>
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className='grid grid-cols-1 gap-4 sm:grid-cols-3'>
+        {metrics.map((m) => {
+          const Icon = icons[m.label as keyof typeof icons]
+          return (
+            <div key={m.label} className='flex flex-col rounded border p-4'>
+              <div className='flex items-center justify-between text-sm text-muted-foreground'>
+                <span>{m.label}</span>
+                <Icon className='h-4 w-4' />
               </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Additional Insights */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Top Products */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <TrendingUp className="h-4 w-4" />
-              <span>Top Products</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {mockData.topProducts.map((product, index) => (
-                <div key={index} className="flex justify-between items-center">
-                  <div className="flex items-center space-x-2">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      #{index + 1}
-                    </span>
-                    <div>
-                      <div className="text-sm font-medium">{product.name}</div>
-                      <div className="text-xs text-muted-foreground">{product.sales} units</div>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm font-medium">{formatCurrency(product.revenue)}</div>
-                  </div>
-                </div>
-              ))}
+              <div className='mt-2 text-2xl font-semibold'>{m.value}</div>
+              {m.change && <Badge className='mt-2 w-fit'>{m.change}</Badge>}
             </div>
-          </CardContent>
-        </Card>
-
-        {/* Customer Satisfaction */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <Star className="h-4 w-4" />
-              <span>Customer Satisfaction</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="text-center">
-              <div className="text-3xl font-bold">{mockData.customerSatisfaction.rating}</div>
-              <div className="text-sm text-muted-foreground">Average Rating</div>
-              <div className="flex justify-center mt-1">
-                {Array.from({ length: 5 }, (_, i) => (
-                  <Star 
-                    key={i} 
-                    className={`h-4 w-4 ${
-                      i < Math.floor(mockData.customerSatisfaction.rating) 
-                        ? 'text-yellow-500 fill-current' 
-                        : 'text-gray-300'
-                    }`} 
-                  />
-                ))}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm">Total Reviews</span>
-                <span className="text-sm font-medium">{mockData.customerSatisfaction.reviews}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Compliments</span>
-                <span className="text-sm font-medium text-green-600">{mockData.customerSatisfaction.compliments}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm">Complaints</span>
-                <span className="text-sm font-medium text-red-600">{mockData.customerSatisfaction.complaints}</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Inventory Alert */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <AlertTriangle className="h-4 w-4" />
-              <span>Inventory Alerts</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex justify-between items-center">
-              <span className="text-sm">In Stock</span>
-              <Badge variant="outline" className="text-green-600 border-green-600">
-                {mockData.inventoryLevels.inStock} items
-              </Badge>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-sm">Low Stock</span>
-              <Badge variant="outline" className="text-yellow-600 border-yellow-600">
-                {mockData.inventoryLevels.lowStock} items
-              </Badge>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-sm">Out of Stock</span>
-              <Badge variant="outline" className="text-red-600 border-red-600">
-                {mockData.inventoryLevels.outOfStock} items
-              </Badge>
-            </div>
-            <div className="pt-2 border-t">
-              <div className="text-xs text-muted-foreground">
-                Reorder alerts for {mockData.inventoryLevels.lowStock + mockData.inventoryLevels.outOfStock} items
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+          )
+        })}
+      </CardContent>
+    </Card>
   )
 }
+

--- a/components/fragment-inventory-management.tsx
+++ b/components/fragment-inventory-management.tsx
@@ -34,7 +34,7 @@ export function FragmentInventoryManagement({
     []
   )
 
-  const categories = ['all', ...new Set(items.map((i) => i.category))]
+  const categories = ['all', ...Array.from(new Set(items.map((i) => i.category)))]
   const [category, setCategory] = useState('all')
 
   const filtered = items.filter(

--- a/components/fragment-inventory-management.tsx
+++ b/components/fragment-inventory-management.tsx
@@ -1,644 +1,92 @@
 'use client'
 
 import { InventoryManagementFragmentSchema } from '@/lib/schema'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { 
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { 
-  Package, 
-  AlertTriangle, 
-  TrendingUp, 
-  TrendingDown,
-  BarChart3, 
-  RefreshCw,
-  Search,
-  Filter,
-  Download,
-  Plus,
-  Minus,
-  ShoppingCart,
-  Truck,
-  Clock,
-  DollarSign,
-  Target,
-  Archive,
-  CheckCircle,
-  XCircle,
-  Eye,
-  Edit,
-  MoreHorizontal
-} from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useMemo, useState } from 'react'
 
-interface InventoryItem {
+interface Item {
   id: string
   name: string
-  sku: string
+  stock: number
+  min: number
   category: string
-  currentStock: number
-  minStock: number
-  maxStock: number
-  reorderPoint: number
-  unitCost: number
-  unitPrice: number
-  supplier: string
-  location: string
-  lastRestocked: string
-  status: 'in_stock' | 'low_stock' | 'out_of_stock' | 'overstocked'
-  trend: 'up' | 'down' | 'stable'
-  weeklyMovement: number
-  monthlyMovement: number
-  image?: string
 }
 
-interface Category {
-  id: string
-  name: string
-  totalItems: number
-  lowStockItems: number
-  outOfStockItems: number
-  totalValue: number
-}
+export function FragmentInventoryManagement({
+  fragment,
+}: {
+  fragment: InventoryManagementFragmentSchema
+}) {
+  const items = useMemo<Item[]>(
+    () => [
+      { id: '1', name: 'Sample Item A', stock: 12, min: 5, category: 'General' },
+      { id: '2', name: 'Sample Item B', stock: 2, min: 5, category: 'General' },
+      { id: '3', name: 'Sample Item C', stock: 30, min: 10, category: 'Seasonal' },
+    ],
+    []
+  )
 
-export function FragmentInventoryManagement({ fragment }: { fragment: InventoryManagementFragmentSchema }) {
-  const [inventoryData, setInventoryData] = useState(generateMockInventoryData())
-  const [lastUpdated, setLastUpdated] = useState(new Date())
-  const [selectedCategory, setSelectedCategory] = useState<string>('all')
-  const [selectedStore, setSelectedStore] = useState('main')
-  const [searchTerm, setSearchTerm] = useState('')
-  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const categories = ['all', ...new Set(items.map((i) => i.category))]
+  const [category, setCategory] = useState('all')
 
-  function generateMockInventoryData() {
-    const stores = [
-      { id: 'main', name: fragment.store_name || 'Main Store' },
-      { id: 'downtown', name: 'Downtown Branch' },
-      { id: 'mall', name: 'Mall Location' },
-      { id: 'suburban', name: 'Suburban Store' }
-    ]
-
-    const categories: Category[] = [
-      { id: 'electronics', name: 'Electronics', totalItems: 45, lowStockItems: 3, outOfStockItems: 1, totalValue: 125000 },
-      { id: 'clothing', name: 'Clothing', totalItems: 120, lowStockItems: 8, outOfStockItems: 2, totalValue: 85000 },
-      { id: 'food', name: 'Food & Beverages', totalItems: 200, lowStockItems: 15, outOfStockItems: 5, totalValue: 45000 },
-      { id: 'home', name: 'Home & Garden', totalItems: 80, lowStockItems: 4, outOfStockItems: 1, totalValue: 65000 },
-      { id: 'health', name: 'Health & Beauty', totalItems: 60, lowStockItems: 2, outOfStockItems: 0, totalValue: 35000 }
-    ]
-
-    const inventoryItems: InventoryItem[] = [
-      {
-        id: 'inv-001',
-        name: 'Samsung 55" 4K Smart TV',
-        sku: 'SAM-TV-55-001',
-        category: 'Electronics',
-        currentStock: 8,
-        minStock: 5,
-        maxStock: 25,
-        reorderPoint: 10,
-        unitCost: 450,
-        unitPrice: 699,
-        supplier: 'Samsung Electronics',
-        location: 'Warehouse A-1',
-        lastRestocked: '2025-01-28',
-        status: 'in_stock',
-        trend: 'down',
-        weeklyMovement: -3,
-        monthlyMovement: -12
-      },
-      {
-        id: 'inv-002',
-        name: 'Apple iPhone 15 Pro',
-        sku: 'APL-IP15P-001',
-        category: 'Electronics',
-        currentStock: 2,
-        minStock: 5,
-        maxStock: 20,
-        reorderPoint: 8,
-        unitCost: 850,
-        unitPrice: 1199,
-        supplier: 'Apple Inc.',
-        location: 'Secure Storage',
-        lastRestocked: '2025-01-25',
-        status: 'low_stock',
-        trend: 'up',
-        weeklyMovement: 8,
-        monthlyMovement: 25
-      },
-      {
-        id: 'inv-003',
-        name: 'Nike Air Max Sneakers',
-        sku: 'NIKE-AM-001',
-        category: 'Clothing',
-        currentStock: 0,
-        minStock: 10,
-        maxStock: 50,
-        reorderPoint: 15,
-        unitCost: 65,
-        unitPrice: 129,
-        supplier: 'Nike Distribution',
-        location: 'Floor Display',
-        lastRestocked: '2025-01-20',
-        status: 'out_of_stock',
-        trend: 'up',
-        weeklyMovement: 0,
-        monthlyMovement: -45
-      },
-      {
-        id: 'inv-004',
-        name: 'Organic Coffee Beans 1kg',
-        sku: 'ORG-COF-1KG',
-        category: 'Food & Beverages',
-        currentStock: 45,
-        minStock: 20,
-        maxStock: 100,
-        reorderPoint: 30,
-        unitCost: 12,
-        unitPrice: 24,
-        supplier: 'Fair Trade Coffee Co.',
-        location: 'Aisle 3-B',
-        lastRestocked: '2025-02-01',
-        status: 'in_stock',
-        trend: 'stable',
-        weeklyMovement: 15,
-        monthlyMovement: 55
-      },
-      {
-        id: 'inv-005',
-        name: 'Wireless Bluetooth Headphones',
-        sku: 'WL-BT-HP-001',
-        category: 'Electronics',
-        currentStock: 3,
-        minStock: 8,
-        maxStock: 30,
-        reorderPoint: 12,
-        unitCost: 35,
-        unitPrice: 79,
-        supplier: 'Audio Tech Ltd.',
-        location: 'Electronics Section',
-        lastRestocked: '2025-01-30',
-        status: 'low_stock',
-        trend: 'up',
-        weeklyMovement: 5,
-        monthlyMovement: 18
-      },
-      {
-        id: 'inv-006',
-        name: 'Premium Skincare Set',
-        sku: 'PREM-SKIN-SET',
-        category: 'Health & Beauty',
-        currentStock: 25,
-        minStock: 10,
-        maxStock: 40,
-        reorderPoint: 15,
-        unitCost: 28,
-        unitPrice: 65,
-        supplier: 'Beauty Essentials',
-        location: 'Beauty Counter',
-        lastRestocked: '2025-01-29',
-        status: 'in_stock',
-        trend: 'up',
-        weeklyMovement: 8,
-        monthlyMovement: 22
-      }
-    ]
-
-    return {
-      stores,
-      categories,
-      inventoryItems,
-      summary: {
-        totalItems: inventoryItems.length,
-        totalValue: inventoryItems.reduce((sum, item) => sum + (item.currentStock * item.unitCost), 0),
-        lowStockItems: inventoryItems.filter(item => item.status === 'low_stock').length,
-        outOfStockItems: inventoryItems.filter(item => item.status === 'out_of_stock').length,
-        reorderAlerts: inventoryItems.filter(item => item.currentStock <= item.reorderPoint).length,
-        topMovingItems: inventoryItems.sort((a, b) => b.monthlyMovement - a.monthlyMovement).slice(0, 5)
-      }
-    }
-  }
-
-  function refreshData() {
-    setInventoryData(generateMockInventoryData())
-    setLastUpdated(new Date())
-  }
-
-  function formatCurrency(amount: number) {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD'
-    }).format(amount)
-  }
-
-  function getStatusColor(status: string) {
-    switch (status) {
-      case 'in_stock': return 'text-green-600 border-green-600 bg-green-50'
-      case 'low_stock': return 'text-yellow-600 border-yellow-600 bg-yellow-50'
-      case 'out_of_stock': return 'text-red-600 border-red-600 bg-red-50'
-      case 'overstocked': return 'text-blue-600 border-blue-600 bg-blue-50'
-      default: return 'text-gray-600 border-gray-600 bg-gray-50'
-    }
-  }
-
-  function getTrendIcon(trend: string) {
-    switch (trend) {
-      case 'up': return <TrendingUp className="h-4 w-4 text-green-600" />
-      case 'down': return <TrendingDown className="h-4 w-4 text-red-600" />
-      case 'stable': return <Minus className="h-4 w-4 text-blue-600" />
-      default: return <Minus className="h-4 w-4 text-gray-600" />
-    }
-  }
-
-  const currentStore = inventoryData.stores.find(store => store.id === selectedStore) || inventoryData.stores[0]
-
-  // Filter inventory items based on search and filters
-  const filteredItems = inventoryData.inventoryItems.filter(item => {
-    const matchesSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         item.sku.toLowerCase().includes(searchTerm.toLowerCase())
-    const matchesCategory = selectedCategory === 'all' || item.category.toLowerCase() === selectedCategory.toLowerCase()
-    const matchesStatus = statusFilter === 'all' || item.status === statusFilter
-    
-    return matchesSearch && matchesCategory && matchesStatus
-  })
-
-  const MetricCard = ({ 
-    title, 
-    value, 
-    icon: Icon, 
-    formatter = (val: number) => val.toLocaleString(),
-    color = 'text-orange-600',
-    bgColor = 'bg-orange-50'
-  }: {
-    title: string
-    value: number
-    icon: any
-    formatter?: (val: number) => string
-    color?: string
-    bgColor?: string
-  }) => (
-    <Card className="border-orange-100 dark:border-orange-900/30">
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
-        <div className={`p-2 rounded-lg ${bgColor}`}>
-          <Icon className={`h-4 w-4 ${color}`} />
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-bold">{formatter(value)}</div>
-      </CardContent>
-    </Card>
+  const filtered = items.filter(
+    (i) => category === 'all' || i.category === category
   )
 
   return (
-    <div className="flex flex-col h-full p-4 space-y-6 overflow-y-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-2">
-          <Package className="h-5 w-5 text-orange-600" />
-          <h2 className="text-xl font-semibold">Inventory Management - {currentStore.name}</h2>
-          <Badge variant="outline" className="border-orange-200 text-orange-700">{fragment.time_period}</Badge>
-        </div>
-        <div className="flex items-center space-x-2">
-          <Select value={selectedStore} onValueChange={setSelectedStore}>
-            <SelectTrigger className="w-48">
-              <SelectValue placeholder="Select store" />
-            </SelectTrigger>
-            <SelectContent>
-              {inventoryData.stores.map((store) => (
-                <SelectItem key={store.id} value={store.id}>
-                  {store.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <span className="text-sm text-muted-foreground">
-            Updated: {lastUpdated.toLocaleTimeString()}
-          </span>
-          <Button
-            onClick={refreshData}
-            variant="outline"
-            size="sm"
-            className="h-8 border-orange-200 text-orange-700 hover:bg-orange-50"
-          >
-            <RefreshCw className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Key Metrics Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          title="Total Items"
-          value={inventoryData.summary.totalItems}
-          icon={Package}
-        />
-        <MetricCard
-          title="Total Value"
-          value={inventoryData.summary.totalValue}
-          icon={DollarSign}
-          formatter={formatCurrency}
-          color="text-green-600"
-          bgColor="bg-green-50"
-        />
-        <MetricCard
-          title="Low Stock Alerts"
-          value={inventoryData.summary.lowStockItems}
-          icon={AlertTriangle}
-          color="text-yellow-600"
-          bgColor="bg-yellow-50"
-        />
-        <MetricCard
-          title="Out of Stock"
-          value={inventoryData.summary.outOfStockItems}
-          icon={XCircle}
-          color="text-red-600"
-          bgColor="bg-red-50"
-        />
-      </div>
-
-      {/* Filters and Search */}
-      <Card className="border-orange-100 dark:border-orange-900/30">
-        <CardContent className="p-4">
-          <div className="flex flex-col md:flex-row gap-4">
-            <div className="flex-1">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  placeholder="Search by name or SKU..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-10 pr-4 py-2 border border-orange-200 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                />
-              </div>
-            </div>
-            <Select value={selectedCategory} onValueChange={setSelectedCategory}>
-              <SelectTrigger className="w-48">
-                <SelectValue placeholder="All Categories" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Categories</SelectItem>
-                {inventoryData.categories.map((category) => (
-                  <SelectItem key={category.id} value={category.name}>
-                    {category.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-48">
-                <SelectValue placeholder="All Status" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Status</SelectItem>
-                <SelectItem value="in_stock">In Stock</SelectItem>
-                <SelectItem value="low_stock">Low Stock</SelectItem>
-                <SelectItem value="out_of_stock">Out of Stock</SelectItem>
-                <SelectItem value="overstocked">Overstocked</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Categories Overview */}
-      <Card className="border-orange-100 dark:border-orange-900/30">
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <BarChart3 className="h-4 w-4 text-orange-600" />
-            <span>Categories Overview</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            {inventoryData.categories.map((category, index) => (
-              <div key={category.id} className="p-4 border rounded-lg border-orange-100 dark:border-orange-900/30 hover:bg-orange-50 dark:hover:bg-orange-950/30 transition-colors">
-                <div className="text-center">
-                  <div className="text-lg font-bold text-orange-600">{category.totalItems}</div>
-                  <div className="text-sm font-medium">{category.name}</div>
-                  <div className="text-xs text-muted-foreground mt-1">
-                    {formatCurrency(category.totalValue)}
-                  </div>
-                  <div className="flex justify-center space-x-2 mt-2">
-                    {category.lowStockItems > 0 && (
-                      <Badge variant="outline" className="text-xs text-yellow-600 border-yellow-600">
-                        {category.lowStockItems} Low
-                      </Badge>
-                    )}
-                    {category.outOfStockItems > 0 && (
-                      <Badge variant="outline" className="text-xs text-red-600 border-red-600">
-                        {category.outOfStockItems} Out
-                      </Badge>
-                    )}
-                  </div>
-                </div>
-              </div>
+    <Card className='h-full flex flex-col'>
+      <CardHeader className='flex-row items-center justify-between space-y-0 pb-2'>
+        <CardTitle className='text-lg'>{fragment.store_name} Inventory</CardTitle>
+        <Select value={category} onValueChange={setCategory}>
+          <SelectTrigger className='w-40'>
+            <SelectValue placeholder='Category' />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
             ))}
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Inventory Items Table */}
-      <Card className="border-orange-100 dark:border-orange-900/30">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center space-x-2">
-              <Archive className="h-4 w-4 text-orange-600" />
-              <span>Inventory Items ({filteredItems.length})</span>
-            </CardTitle>
-            <div className="flex space-x-2">
-              <Button variant="outline" size="sm" className="border-orange-200 text-orange-700 hover:bg-orange-50">
-                <Download className="h-4 w-4 mr-2" />
-                Export
-              </Button>
-              <Button size="sm" className="bg-orange-500 hover:bg-orange-600">
-                <Plus className="h-4 w-4 mr-2" />
-                Add Item
-              </Button>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-orange-100">
-                  <th className="text-left p-3 font-medium">Product</th>
-                  <th className="text-left p-3 font-medium">SKU</th>
-                  <th className="text-left p-3 font-medium">Category</th>
-                  <th className="text-left p-3 font-medium">Stock</th>
-                  <th className="text-left p-3 font-medium">Status</th>
-                  <th className="text-left p-3 font-medium">Value</th>
-                  <th className="text-left p-3 font-medium">Trend</th>
-                  <th className="text-left p-3 font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredItems.map((item) => (
-                  <tr key={item.id} className="border-b border-orange-50 hover:bg-orange-50/50 transition-colors">
-                    <td className="p-3">
-                      <div>
-                        <div className="font-medium">{item.name}</div>
-                        <div className="text-sm text-muted-foreground">{item.supplier}</div>
-                      </div>
-                    </td>
-                    <td className="p-3">
-                      <code className="text-sm bg-gray-100 px-2 py-1 rounded">{item.sku}</code>
-                    </td>
-                    <td className="p-3">
-                      <Badge variant="outline" className="text-xs">
-                        {item.category}
-                      </Badge>
-                    </td>
-                    <td className="p-3">
-                      <div>
-                        <div className="font-medium">{item.currentStock}</div>
-                        <div className="text-xs text-muted-foreground">
-                          Min: {item.minStock} | Max: {item.maxStock}
-                        </div>
-                      </div>
-                    </td>
-                    <td className="p-3">
-                      <Badge variant="outline" className={`text-xs ${getStatusColor(item.status)}`}>
-                        {item.status.replace('_', ' ')}
-                      </Badge>
-                    </td>
-                    <td className="p-3">
-                      <div>
-                        <div className="font-medium">{formatCurrency(item.currentStock * item.unitCost)}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {formatCurrency(item.unitCost)} each
-                        </div>
-                      </div>
-                    </td>
-                    <td className="p-3">
-                      <div className="flex items-center space-x-1">
-                        {getTrendIcon(item.trend)}
-                        <span className="text-sm">{item.monthlyMovement > 0 ? '+' : ''}{item.monthlyMovement}</span>
-                      </div>
-                    </td>
-                    <td className="p-3">
-                      <div className="flex space-x-1">
-                        <Button variant="outline" size="sm" className="h-8 w-8 p-0">
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        <Button variant="outline" size="sm" className="h-8 w-8 p-0">
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button variant="outline" size="sm" className="h-8 w-8 p-0">
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Quick Actions and Alerts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Reorder Alerts */}
-        <Card className="border-orange-100 dark:border-orange-900/30">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <AlertTriangle className="h-4 w-4 text-orange-600" />
-              <span>Reorder Alerts</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {inventoryData.inventoryItems
-                .filter(item => item.currentStock <= item.reorderPoint)
-                .slice(0, 5)
-                .map((item) => (
-                  <div key={item.id} className="flex items-center justify-between p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-                    <div>
-                      <div className="font-medium text-sm">{item.name}</div>
-                      <div className="text-xs text-muted-foreground">
-                        Current: {item.currentStock} | Reorder at: {item.reorderPoint}
-                      </div>
-                    </div>
-                    <Button size="sm" className="bg-orange-500 hover:bg-orange-600">
-                      <ShoppingCart className="h-4 w-4 mr-1" />
-                      Reorder
-                    </Button>
-                  </div>
-                ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Top Moving Items */}
-        <Card className="border-orange-100 dark:border-orange-900/30">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <TrendingUp className="h-4 w-4 text-orange-600" />
-              <span>Top Moving Items</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {inventoryData.summary.topMovingItems.map((item, index) => (
-                <div key={item.id} className="flex items-center justify-between p-3 border rounded-lg border-orange-100 dark:border-orange-900/30">
-                  <div className="flex items-center space-x-3">
-                    <span className="text-sm font-medium text-muted-foreground">#{index + 1}</span>
-                    <div>
-                      <div className="font-medium text-sm">{item.name}</div>
-                      <div className="text-xs text-muted-foreground">
-                        Stock: {item.currentStock}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm font-medium text-green-600">
-                      +{item.monthlyMovement} units
-                    </div>
-                    <div className="text-xs text-muted-foreground">this month</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Summary Insights */}
-      <Card className="bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950 dark:to-amber-950 border-orange-200 dark:border-orange-800">
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Target className="h-4 w-4 text-orange-600" />
-            <span>Inventory Insights</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
-            <div className="flex items-center space-x-2">
-              <CheckCircle className="h-4 w-4 text-green-600" />
-              <span>85% items properly stocked</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <AlertTriangle className="h-4 w-4 text-yellow-600" />
-              <span>{inventoryData.summary.reorderAlerts} items need reordering</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <TrendingUp className="h-4 w-4 text-blue-600" />
-              <span>Electronics category trending up</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <DollarSign className="h-4 w-4 text-green-600" />
-              <span>Total inventory value: {formatCurrency(inventoryData.summary.totalValue)}</span>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className='flex-1 overflow-auto'>
+        <table className='w-full text-sm'>
+          <thead>
+            <tr className='text-left'>
+              <th className='pb-2'>Item</th>
+              <th className='pb-2'>Stock</th>
+              <th className='pb-2'>Status</th>
+            </tr>
+          </thead>
+          <tbody className='divide-y'>
+            {filtered.map((item) => (
+              <tr key={item.id}>
+                <td className='py-2'>{item.name}</td>
+                <td className='py-2'>{item.stock}</td>
+                <td className='py-2'>
+                  {item.stock <= 0 ? (
+                    <Badge variant='destructive'>Out</Badge>
+                  ) : item.stock < item.min ? (
+                    <Badge variant='secondary'>Low</Badge>
+                  ) : (
+                    <Badge variant='outline'>OK</Badge>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   )
 }
+

--- a/components/fragment-sales-data.tsx
+++ b/components/fragment-sales-data.tsx
@@ -1,552 +1,75 @@
 'use client'
 
 import { SalesDataFragmentSchema } from '@/lib/schema'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { 
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { 
-  DollarSign, 
-  TrendingUp, 
-  TrendingDown,
-  ShoppingCart, 
-  Users, 
-  Package,
-  Calendar,
-  RefreshCw,
-  Target,
-  Clock,
-  Star,
-  ArrowUpRight,
-  ArrowDownRight,
-  BarChart3,
-  PieChart,
-  Activity,
-  CreditCard,
-  Percent,
-  Award
-} from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { DollarSign, ShoppingCart, Users } from 'lucide-react'
+import { useState } from 'react'
 
-// Define specific types for each timeframe
-type DailySalesData = {
-  date: string
-  revenue: number
-  transactions: number
-  customers: number
-  avgOrderValue: number
-}
+export function FragmentSalesData({
+  fragment,
+}: {
+  fragment: SalesDataFragmentSchema
+}) {
+  const [period, setPeriod] = useState(fragment.time_period)
 
-type WeeklySalesData = {
-  week: string
-  revenue: number
-  transactions: number
-  customers: number
-  avgOrderValue: number
-}
-
-type MonthlySalesData = {
-  month: string
-  revenue: number
-  transactions: number
-  customers: number
-  avgOrderValue: number
-}
-
-type QuarterlySalesData = {
-  quarter: string
-  revenue: number
-  transactions: number
-  customers: number
-  avgOrderValue: number
-}
-
-// Union type for chart data
-type SalesData = DailySalesData | WeeklySalesData | MonthlySalesData | QuarterlySalesData
-
-export function FragmentSalesData({ fragment }: { fragment: SalesDataFragmentSchema }) {
-  const [lastUpdated, setLastUpdated] = useState(new Date('2025-02-02'))
-  const [selectedTimeframe, setSelectedTimeframe] = useState<'daily' | 'weekly' | 'monthly' | 'quarterly'>('daily')
-  const [selectedStore, setSelectedStore] = useState('mall')
-
-  // Use the specific data provided by the user
-  const mockData = {
-    stores: [
-      { id: 'mall', name: 'Mall of India Store' },
-      { id: 'downtown', name: 'Downtown Branch' },
-      { id: 'main', name: 'Main Store' },
-      { id: 'suburban', name: 'Suburban Store' }
-    ],
-    currentMetrics: {
-      totalRevenue: 1838638,
-      previousRevenue: 1495000, // Calculated to give +23.1%
-      totalTransactions: 705,
-      previousTransactions: 593, // Calculated to give +18.9%
-      avgOrderValue: 2608,
-      previousAvgOrderValue: 2752, // Calculated to give -5.2%
-      totalCustomers: 658,
-      previousCustomers: 650,
-      conversionRate: "6.6",
-      previousConversionRate: "5.4", // Calculated to give +1.2%
-      returnCustomers: "6.6",
-      previousReturnCustomers: "5.4"
-    },
-    topProducts: [
-      { name: 'Begum Wing Chair - Monkies', revenue: 35238.35, units: 2, growth: "18.5" },
-      { name: 'Marigold Steel Digital Print Bottle', revenue: 18814.5, units: 13, growth: "12.3" },
-      { name: 'Quirky India Steel Sipper Bottle', revenue: 18309, units: 13, growth: "8.7" },
-      { name: 'Travel Patches Tote Bag', revenue: 17578, units: 7, growth: "15.2" },
-      { name: 'Olive Palm Quilted Crossbody Bag', revenue: 16987.25, units: 7, growth: "-3.4" }
-    ],
-    salesByCategory: [
-      { category: 'Sippers & Bottles', revenue: 176500, percentage: 9.6 },
-      { category: 'Tote Bags', revenue: 143414, percentage: 7.8 },
-      { category: 'Fridge Magnets', revenue: 119511, percentage: 6.5 },
-      { category: 'Mugs & Cups', revenue: 117633, percentage: 6.4 },
-      { category: 'Crossbody Bags', revenue: 108480, percentage: 5.9 }
-    ],
-    paymentMethods: [
-      { method: 'Credit Card', percentage: 45, transactions: 317 },
-      { method: 'Debit Card', percentage: 30, transactions: 212 },
-      { method: 'Cash', percentage: 15, transactions: 106 },
-      { method: 'Mobile Pay', percentage: 8, transactions: 56 },
-      { method: 'Gift Card', percentage: 2, transactions: 14 }
-    ],
-    hourlyTrends: Array.from({ length: 24 }, (_, hour) => ({
-      hour: `${hour.toString().padStart(2, '0')}:00`,
-      revenue: Math.floor(Math.random() * 2000) + (hour >= 9 && hour <= 21 ? 500 : 100),
-      transactions: Math.floor(Math.random() * 50) + (hour >= 9 && hour <= 21 ? 20 : 5)
-    })),
-    dailySales: Array.from({ length: 30 }, (_, i) => {
-      const date = new Date('2025-02-02')
-      date.setDate(date.getDate() - (29 - i))
-      return {
-        date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-        revenue: Math.floor(Math.random() * 80000) + 40000,
-        transactions: Math.floor(Math.random() * 30) + 15,
-        customers: Math.floor(Math.random() * 40) + 20,
-        avgOrderValue: Math.floor(Math.random() * 1000) + 2000
-      }
-    }) as DailySalesData[],
-    weeklySales: Array.from({ length: 12 }, (_, i) => ({
-      week: `Week ${i + 1}`,
-      revenue: Math.floor(Math.random() * 500000) + 300000,
-      transactions: Math.floor(Math.random() * 200) + 100,
-      customers: Math.floor(Math.random() * 300) + 150,
-      avgOrderValue: Math.floor(Math.random() * 1000) + 2000
-    })) as WeeklySalesData[],
-    monthlySales: Array.from({ length: 12 }, (_, i) => {
-      const date = new Date('2025-02-02')
-      date.setMonth(date.getMonth() - (11 - i))
-      return {
-        month: date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' }),
-        revenue: Math.floor(Math.random() * 2000000) + 1000000,
-        transactions: Math.floor(Math.random() * 800) + 400,
-        customers: Math.floor(Math.random() * 1200) + 600,
-        avgOrderValue: Math.floor(Math.random() * 1000) + 2000
-      }
-    }) as MonthlySalesData[],
-    quarterlySales: Array.from({ length: 8 }, (_, i) => ({
-      quarter: `Q${(i % 4) + 1} '${24 - Math.floor(i / 4)}`,
-      revenue: Math.floor(Math.random() * 6000000) + 3000000,
-      transactions: Math.floor(Math.random() * 2500) + 1500,
-      customers: Math.floor(Math.random() * 4000) + 2000,
-      avgOrderValue: Math.floor(Math.random() * 1000) + 2000
-    })) as QuarterlySalesData[]
-  }
-
-  function refreshData() {
-    setLastUpdated(new Date())
-  }
-
-  function formatCurrency(amount: number) {
-    return new Intl.NumberFormat('en-IN', {
-      style: 'currency',
-      currency: 'INR'
-    }).format(amount)
-  }
-
-  function calculatePercentageChange(current: number, previous: number) {
-    return ((current - previous) / previous * 100).toFixed(1)
-  }
-
-  const getCurrentSalesData = (): SalesData[] => {
-    switch (selectedTimeframe) {
-      case 'weekly': return mockData.weeklySales
-      case 'monthly': return mockData.monthlySales
-      case 'quarterly': return mockData.quarterlySales
-      default: return mockData.dailySales
-    }
-  }
-
-  // Helper function to get label from sales data item with type safety
-  const getLabel = (item: SalesData, timeframe: 'daily' | 'weekly' | 'monthly' | 'quarterly'): string => {
-    switch (timeframe) {
-      case 'daily':
-        return 'date' in item ? item.date : ''
-      case 'weekly':
-        return 'week' in item ? item.week : ''
-      case 'monthly':
-        return 'month' in item ? item.month : ''
-      case 'quarterly':
-        return 'quarter' in item ? item.quarter : ''
-      default:
-        return ''
-    }
-  }
-
-  const currentStore = mockData.stores.find(store => store.id === selectedStore) || mockData.stores[0]
-
-  const MetricCard = ({ 
-    title, 
-    value, 
-    previousValue, 
-    icon: Icon, 
-    formatter = (val: number) => val.toLocaleString(),
-    suffix = '',
-    trend,
-    isPercentage = false
-  }: {
-    title: string
-    value: number | string
-    previousValue?: number | string
-    icon: any
-    formatter?: (val: number) => string
-    suffix?: string
-    trend?: 'up' | 'down'
-    isPercentage?: boolean
-  }) => {
-    const numValue = typeof value === 'string' ? parseFloat(value) : value
-    const numPrevValue = typeof previousValue === 'string' ? parseFloat(previousValue as string) : previousValue
-    const percentChange = numPrevValue ? calculatePercentageChange(numValue, numPrevValue) : null
-    const isPositive = percentChange ? parseFloat(percentChange) > 0 : trend === 'up'
-    
-    return (
-      <Card className="border-orange-100 dark:border-orange-900/30">
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">{title}</CardTitle>
-          <Icon className="h-4 w-4 text-muted-foreground" />
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {typeof value === 'string' ? value + suffix : formatter(value)}{suffix}
-          </div>
-          {percentChange && (
-            <div className={`text-xs flex items-center space-x-1 ${
-              isPositive ? 'text-green-600' : 'text-red-600'
-            }`}>
-              {isPositive ? (
-                <ArrowUpRight className="h-3 w-3" />
-              ) : (
-                <ArrowDownRight className="h-3 w-3" />
-              )}
-              <span>{isPositive ? '+' : ''}{percentChange}% from last period</span>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    )
-  }
-
-  const SalesChart = () => {
-    const data = getCurrentSalesData()
-    const maxRevenue = Math.max(...data.map(d => d.revenue))
-    
-    return (
-      <Card className="col-span-2 border-orange-100 dark:border-orange-900/30">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center space-x-2">
-              <BarChart3 className="h-4 w-4 text-orange-600" />
-              <span>Sales Revenue Trends</span>
-            </CardTitle>
-            <div className="flex space-x-1">
-              {(['daily', 'weekly', 'monthly', 'quarterly'] as const).map((timeframe) => (
-                <Button
-                  key={timeframe}
-                  variant={selectedTimeframe === timeframe ? 'default' : 'outline'}
-                  size="sm"
-                  onClick={() => setSelectedTimeframe(timeframe)}
-                  className={`text-xs ${
-                    selectedTimeframe === timeframe 
-                      ? 'bg-orange-500 hover:bg-orange-600 text-white' 
-                      : 'border-orange-200 text-orange-700 hover:bg-orange-50'
-                  }`}
-                >
-                  {timeframe.charAt(0).toUpperCase() + timeframe.slice(1)}
-                </Button>
-              ))}
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div className="h-64 flex items-end space-x-1 bg-gradient-to-t from-orange-50/30 to-transparent rounded-lg p-4">
-              {data.slice(-15).map((item, index) => {
-                const height = (item.revenue / maxRevenue) * 100
-                const label = getLabel(item, selectedTimeframe)
-                return (
-                  <div key={index} className="flex-1 flex flex-col items-center">
-                    <div 
-                      className="w-full bg-gradient-to-t from-orange-600 to-orange-400 rounded-t-sm hover:from-orange-700 hover:to-orange-500 transition-colors cursor-pointer shadow-sm"
-                      style={{ height: `${height}%` }}
-                      title={`${label}: ${formatCurrency(item.revenue)}`}
-                    />
-                    <span className="text-xs text-muted-foreground mt-1 transform -rotate-45 origin-left">
-                      {label}
-                    </span>
-                  </div>
-                )
-              })}
-            </div>
-            <div className="grid grid-cols-4 gap-4 text-sm">
-              <div className="text-center">
-                <div className="font-semibold">{formatCurrency(data[data.length - 1]?.revenue || 0)}</div>
-                <div className="text-muted-foreground">Latest Revenue</div>
-              </div>
-              <div className="text-center">
-                <div className="font-semibold">{data[data.length - 1]?.transactions || 0}</div>
-                <div className="text-muted-foreground">Transactions</div>
-              </div>
-              <div className="text-center">
-                <div className="font-semibold">{data[data.length - 1]?.customers || 0}</div>
-                <div className="text-muted-foreground">Customers</div>
-              </div>
-              <div className="text-center">
-                <div className="font-semibold">{formatCurrency(data[data.length - 1]?.avgOrderValue || 0)}</div>
-                <div className="text-muted-foreground">Avg Order</div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    )
-  }
+  const metrics = [
+    { label: 'Total Revenue', value: '₹1.84M', icon: DollarSign },
+    { label: 'Transactions', value: '705', icon: ShoppingCart },
+    { label: 'Customers', value: '658', icon: Users },
+  ]
 
   return (
-    <div className="flex flex-col h-full p-4 space-y-6 overflow-y-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-2">
-          <DollarSign className="h-5 w-5 text-orange-600" />
-          <h2 className="text-xl font-semibold">Sales Data - {currentStore.name}</h2>
-          <Badge variant="outline" className="border-orange-200 text-orange-700">This Month</Badge>
-        </div>
-        <div className="flex items-center space-x-2">
-          <Select value={selectedStore} onValueChange={setSelectedStore}>
-            <SelectTrigger className="w-48">
-              <SelectValue placeholder="Select store" />
-            </SelectTrigger>
-            <SelectContent>
-              {mockData.stores.map((store) => (
-                <SelectItem key={store.id} value={store.id}>
-                  {store.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <span className="text-sm text-muted-foreground">
-            Updated: Feb 02, 2025
-          </span>
-          <Button
-            onClick={refreshData}
-            variant="outline"
-            size="sm"
-            className="h-8"
-          >
-            <RefreshCw className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      {/* Key Metrics Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          title="Total Revenue"
-          value={mockData.currentMetrics.totalRevenue}
-          previousValue={mockData.currentMetrics.previousRevenue}
-          icon={DollarSign}
-          formatter={formatCurrency}
-        />
-        <MetricCard
-          title="Total Transactions"
-          value={mockData.currentMetrics.totalTransactions}
-          previousValue={mockData.currentMetrics.previousTransactions}
-          icon={ShoppingCart}
-        />
-        <MetricCard
-          title="Average Order Value"
-          value={mockData.currentMetrics.avgOrderValue}
-          previousValue={mockData.currentMetrics.previousAvgOrderValue}
-          icon={Target}
-          formatter={formatCurrency}
-        />
-        <MetricCard
-          title="Return Customers"
-          value={mockData.currentMetrics.returnCustomers}
-          previousValue={mockData.currentMetrics.previousReturnCustomers}
-          icon={Award}
-          suffix="%"
-        />
-      </div>
-
-      {/* Charts Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <SalesChart />
-        
-        {/* Top Products */}
-        <Card className="border-orange-100 dark:border-orange-900/30">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <Star className="h-4 w-4 text-orange-600" />
-              <span>Top Selling Products</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {mockData.topProducts.map((product, index) => (
-                <div key={index} className="flex justify-between items-center">
-                  <div className="flex items-center space-x-3">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      #{index + 1}
-                    </span>
-                    <div>
-                      <div className="text-sm font-medium">{product.name}</div>
-                      <div className="text-xs text-muted-foreground">{product.units} units sold</div>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm font-medium">{formatCurrency(product.revenue)}</div>
-                    <div className={`text-xs flex items-center ${
-                      product.growth.startsWith('-') ? 'text-red-600' : 'text-green-600'
-                    }`}>
-                      {product.growth.startsWith('-') ? (
-                        <TrendingDown className="h-3 w-3 mr-1" />
-                      ) : (
-                        <TrendingUp className="h-3 w-3 mr-1" />
-                      )}
-                      {product.growth}%
-                    </div>
-                  </div>
-                </div>
-              ))}
+    <Card className='h-full flex flex-col'>
+      <CardHeader className='flex-row items-center justify-between space-y-0 pb-2'>
+        <CardTitle className='text-lg'>{fragment.store_name} Sales</CardTitle>
+        <Select value={period} onValueChange={setPeriod}>
+          <SelectTrigger className='w-40'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {['daily', 'weekly', 'monthly', 'quarterly'].map((p) => (
+              <SelectItem key={p} value={p}>
+                {p}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className='grid grid-cols-1 gap-4 sm:grid-cols-3'>
+        {metrics.map((m) => (
+          <div key={m.label} className='flex flex-col rounded border p-4'>
+            <div className='flex items-center justify-between text-sm text-muted-foreground'>
+              <span>{m.label}</span>
+              <m.icon className='h-4 w-4' />
             </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Sales by Category and Payment Methods */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Sales by Category */}
-        <Card className="border-orange-100 dark:border-orange-900/30">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <PieChart className="h-4 w-4 text-orange-600" />
-              <span>Sales by Category</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {mockData.salesByCategory.map((category, index) => (
-                <div key={index} className="space-y-2">
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm font-medium">{category.category}</span>
-                    <div className="text-right">
-                      <div className="text-sm font-medium">{formatCurrency(category.revenue)}</div>
-                      <div className="text-xs text-muted-foreground">{category.percentage}%</div>
-                    </div>
-                  </div>
-                  <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                    <div 
-                      className="bg-gradient-to-r from-orange-500 to-orange-400 h-2 rounded-full transition-all duration-300"
-                      style={{ width: `${category.percentage}%` }}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Payment Methods */}
-        <Card className="border-orange-100 dark:border-orange-900/30">
-          <CardHeader>
-            <CardTitle className="flex items-center space-x-2">
-              <CreditCard className="h-4 w-4 text-orange-600" />
-              <span>Payment Methods Distribution</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {mockData.paymentMethods.map((method, index) => (
-                <div key={index} className="flex justify-between items-center">
-                  <div className="flex items-center space-x-3">
-                    <div className="text-lg font-bold text-orange-600">{method.percentage}%</div>
-                    <div>
-                      <div className="text-sm font-medium">{method.method}</div>
-                      <div className="text-xs text-muted-foreground">{method.transactions} transactions</div>
-                    </div>
-                  </div>
-                  <div className="w-16 bg-gray-200 dark:bg-gray-700 rounded-full h-2">
-                    <div 
-                      className="bg-gradient-to-r from-green-500 to-green-400 h-2 rounded-full"
-                      style={{ width: `${method.percentage}%` }}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Key Insights */}
-      <Card className="bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-950 dark:to-amber-950 border-orange-200 dark:border-orange-800">
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Activity className="h-4 w-4 text-orange-600" />
-            <span>Key Insights</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
-            <div className="flex items-center space-x-2">
-              <TrendingUp className="h-4 w-4 text-green-600" />
-              <span>Revenue up 23.1% vs last period</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Users className="h-4 w-4 text-blue-600" />
-              <span>Strong performance across all categories</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Award className="h-4 w-4 text-purple-600" />
-              <span>Customer retention at 6.6%</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <Star className="h-4 w-4 text-yellow-600" />
-              <span>Top product: Begum Wing Chair</span>
-            </div>
+            <div className='mt-2 text-2xl font-semibold'>{m.value}</div>
           </div>
-          <div className="mt-4 pt-4 border-t border-orange-200 dark:border-orange-800">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-              <div>
-                <div className="font-medium mb-2">34 returning customers driving repeat sales</div>
-                <div className="text-muted-foreground">High-value furniture items driving revenue</div>
-              </div>
-              <div>
-                <div className="font-medium mb-2">Sippers & Bottles leading category</div>
-                <div className="text-muted-foreground">9.6% of total revenue from this category</div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+        ))}
+        <div className='col-span-full mt-2'>
+          <h3 className='mb-2 text-sm font-medium'>Top Products</h3>
+          <ul className='space-y-1 text-sm'>
+            {[
+              { name: 'Begum Wing Chair', revenue: '₹35k' },
+              { name: 'Steel Bottle', revenue: '₹18k' },
+              { name: 'Tote Bag', revenue: '₹17k' },
+            ].map((p) => (
+              <li key={p.name} className='flex justify-between'>
+                <span>{p.name}</span>
+                <Badge variant='outline'>{p.revenue}</Badge>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardContent>
+    </Card>
   )
 }
+


### PR DESCRIPTION
## Summary
- streamline camera feed with focused controls and grid view
- trim inventory management to a minimal table with status badges
- reduce dashboard and sales components to clean metric cards

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a30ef1b96883249a33d32718b421a1